### PR TITLE
refactor: centralize logging with Python stdlib logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import argparse
 from pathlib import Path
 
 from configs import load_project_config
+from src.logging_utils import init_logging
 from src.utils import get_device, set_seed, maybe_load_hf_token
 
 
@@ -27,6 +28,16 @@ def main() -> None:
     args = parser.parse_args()
 
     project_config = load_project_config(args.config)
+
+    logging_cfg = project_config.logging
+    if logging_cfg:
+        init_logging(
+            console_level=logging_cfg.console_level,
+            component_levels=logging_cfg.components if logging_cfg.components else None,
+        )
+    else:
+        init_logging()
+
     config_dict = project_config.model_dump(mode="python")
     HF_TOKEN = maybe_load_hf_token()
 
@@ -35,8 +46,6 @@ def main() -> None:
 
     if args.stage == "preprocess":
         preprocess_cfg = _require_section(project_config.preprocess, "preprocess")
-        # TODO: add the logging into the preprocessing and then wire this below
-        _require_section(project_config.logging, "logging")
         from src.data.preprocess import run_preprocess
 
         run_preprocess(preprocess_cfg, SEED)
@@ -45,7 +54,6 @@ def main() -> None:
     if args.stage == "train":
         training_cfg = _require_section(project_config.training, "training")
         _require_section(project_config.model, "model")
-        _require_section(project_config.logging, "logging")
         device = get_device(training_cfg.device)
         from src.training.trainer import run_train
 

--- a/src/chat/app.py
+++ b/src/chat/app.py
@@ -1,9 +1,12 @@
 """Gradio chat interface for ParrotLLM."""
 
 import glob
+import logging
 import os
 
 import torch
+
+log = logging.getLogger("parrotllm.chat")
 
 from configs import ProjectConfig
 from src.eval.inference import generate, load_model_from_checkpoint
@@ -33,6 +36,7 @@ def run_chat(project_config: ProjectConfig, *, device: torch.device) -> None:
         state["model"] = model
         state["config"] = ckpt_config
         n_params = model.count_parameters()
+        log.info(f"Loaded checkpoint: {os.path.basename(path)} ({n_params:,} params) on {device}")
         return f"Loaded {os.path.basename(path)} ({n_params:,} params) on {device}"
 
     def chat_fn(message, history):
@@ -82,4 +86,5 @@ def run_chat(project_config: ProjectConfig, *, device: torch.device) -> None:
 
         chatbot = gr.ChatInterface(chat_fn)
 
+    log.info("Launching chat UI...")
     demo.launch()

--- a/src/data/preprocess.py
+++ b/src/data/preprocess.py
@@ -32,6 +32,7 @@ from configs import PreprocessConfig
 import hashlib
 import html
 import itertools
+import logging
 import os
 import random as _random
 import re
@@ -47,6 +48,7 @@ os.environ.setdefault("HF_DATASETS_CACHE", "/tmp/parrotllm_hf_cache")
 from datasets import disable_caching, load_from_disk
 from src.utils import build_tokenizer
 
+log = logging.getLogger("parrotllm.preprocess")
 
 FINGERPRINT_LOWERCASE = True
 _BASE_BOILERPLATE_EXACT = (
@@ -555,7 +557,7 @@ def _get_topic_pipeline():
             device = "cuda"
         else:
             device = "cpu"
-        print(f"  [topic] Loading RoBERTa on device={device!r}...")
+        log.info(f"Loading RoBERTa on device={device!r}...")
         _TOPIC_PIPELINE = pipeline(
             "text-classification",
             model=TOPIC_MODEL_NAME,
@@ -783,8 +785,8 @@ def build_test_decontamination_index(
     if wiki_path.exists():
         split_specs.append(("wikitext-103", wiki_path))
     else:
-        print(
-            f"[decontam] WARNING: Missing Wikitext-103 test split at {wiki_path}."
+        log.warning(
+            f"Missing Wikitext-103 test split at {wiki_path}."
             " Run the download script."
         )
 
@@ -792,17 +794,17 @@ def build_test_decontamination_index(
     if owt_eval_path.exists():
         split_specs.append(("nlp26-owt-eval", owt_eval_path))
     else:
-        print(
-            f"[decontam] WARNING: Missing NLP26 OWT eval split at {owt_eval_path}."
+        log.warning(
+            f"Missing NLP26 OWT eval split at {owt_eval_path}."
             " Run the download script."
         )
 
     if not split_specs:
-        print("[decontam] No evaluation splits found; contamination checks disabled.")
+        log.info("No evaluation splits found; contamination checks disabled.")
         return TestDecontaminationIndex(content_hashes=content_hashes)
 
     for name, path in split_specs:
-        print(f"[decontam] Indexing {name} set...")
+        log.info(f"Indexing {name} set...")
         dataset = load_from_disk(str(path))
         before_hashes = len(content_hashes)
 
@@ -831,9 +833,9 @@ def build_test_decontamination_index(
             if fp:
                 content_hashes.add(fp)
 
-        print(f"  -> {len(content_hashes) - before_hashes:,} new hashes")
+        log.info(f"  -> {len(content_hashes) - before_hashes:,} new hashes")
 
-    print(f"[decontam] Total test hashes: {len(content_hashes):,}")
+    log.info(f"Total test hashes: {len(content_hashes):,}")
     return TestDecontaminationIndex(content_hashes=content_hashes)
 
 
@@ -906,14 +908,6 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
     out_dir = data_dir / "processed"
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    '''
-    # if the random seed is set: the output stream must be the same 
-    # i.e. if run twice same 
-    import random
-    print(random.randint(1, 10))
-    print(random.randint(1, 10))
-    '''
-
     # Load dataset
     target_tokens = getattr(args, "target_tokens", None)
     subset_seed = seed
@@ -921,8 +915,8 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
     if target_tokens is not None:
         subset_path = data_dir / f"openwebtext-subset-{target_tokens}-seed{subset_seed}"
         if not subset_path.exists():
-            print(
-                f"[data] Subset not found at {subset_path}. "
+            log.info(
+                f"Subset not found at {subset_path}. "
                 "Downloading now..."
             )
             from src.scripts.download_data import download_openwebtext_subset_by_tokens
@@ -931,16 +925,16 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
                 seed=subset_seed,
                 data_dir=data_dir,
             )
-        print(
-            f"[data] Loading token-budget subset "
+        log.info(
+            f"Loading token-budget subset "
             f"(target={target_tokens:,} tokens, seed={subset_seed})..."
         )
         ds = load_from_disk(str(subset_path))
     elif args.dataset_size == "small":
-        print("[data] Loading 10k subset...")
+        log.info("Loading 10k subset...")
         ds = load_from_disk(str(data_dir / "openwebtext-10k"))
     elif args.dataset_size == "dummy":
-        print("[data] Loading 100 subset...")
+        log.info("Loading 100 subset...")
         ds = load_from_disk(str(data_dir / "openwebtext-100"))
     else:
         local_path = data_dir / "openwebtext"
@@ -949,10 +943,10 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
                 f"Full OpenWebText not found at {local_path}. "
                 "Run: uv run python src/scripts/download_data.py openwebtext-full"
             )
-        print("[data] Loading full OpenWebText from disk...")
+        log.info("Loading full OpenWebText from disk...")
         ds = load_from_disk(str(local_path))
 
-    print(f"[data] Loaded {len(ds):,} documents")
+    log.info(f"Loaded {len(ds):,} documents")
 
     # Load Tokenizer
     from src.utils import DEFAULT_TOKENIZER_NAME
@@ -960,8 +954,8 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
         add_prefix_space=False,
         padding_side="right",
     )
-    print(
-        f"[data] Tokenizer: {DEFAULT_TOKENIZER_NAME}"
+    log.info(
+        f"Tokenizer: {DEFAULT_TOKENIZER_NAME}"
         f" (vocab_size={len(tokenizer):,}, pad_token={tokenizer.pad_token!r})"
     )
 
@@ -976,7 +970,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
     # Build decontamination indexes (ngrams + normalized hashes)
     skip_decontam = getattr(args, "skip_decontam", False)
     if skip_decontam:
-        print("[decontam] Skipping decontamination (--skip-decontam flag set)")
+        log.info("Skipping decontamination (--skip-decontam flag set)")
         test_index = TestDecontaminationIndex(content_hashes=set())
     else:
         test_index = build_test_decontamination_index(
@@ -991,18 +985,18 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
         num_workers = int(num_workers)
 
     total_docs = len(ds)
-    print(f"[preprocess] Processing {total_docs:,} documents (num_workers={num_workers})...")
+    log.info(f"Processing {total_docs:,} documents (num_workers={num_workers})...")
     _t = time.time()
 
     # ── Phase 1: Decontamination ──────────────────────────────────────────
     # Runs first on raw text so sanitization cannot alter hashes and let
     # contaminated documents slip through.
     if skip_decontam:
-        print("\n[phase 1] Decontamination... SKIPPED")
+        log.info("Phase 1: Decontamination... SKIPPED")
         after_decontam = len(ds)
     else:
         _t = time.time()
-        print("\n[phase 1] Decontamination...")
+        log.info("Phase 1: Decontamination...")
         ds = ds.map(
             lambda batch: decontaminate_batch(batch["text"], test_index),
             batched=True,
@@ -1013,7 +1007,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
         ds = ds.filter(lambda row: row["decontam_status"] == "kept", num_proc=num_workers)
         ds = ds.remove_columns(["decontam_status"])
         after_decontam = len(ds)
-        print(
+        log.info(
             f"  kept {after_decontam:,} / {before_decontam:,}"
             f" (removed {before_decontam - after_decontam:,})"
             f"  [{time.time() - _t:.0f}s]"
@@ -1021,7 +1015,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
 
     # ── Phase 2: Sanitization ────────────────────────────────────────────
     _t = time.time()
-    print("\n[phase 2] Sanitization...")
+    log.info("Phase 2: Sanitization...")
     ds = ds.map(
         lambda batch: sanitize_batch(batch["text"]),
         batched=True,
@@ -1032,7 +1026,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
     ds = ds.filter(lambda row: row["sanitize_status"] == "kept", num_proc=num_workers)
     ds = ds.remove_columns(["sanitize_status"])
     after_sanitize = len(ds)
-    print(
+    log.info(
         f"  kept {after_sanitize:,} / {before_sanitize:,}"
         f" (removed {before_sanitize - after_sanitize:,})"
         f"  [{time.time() - _t:.0f}s]"
@@ -1040,7 +1034,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
 
     # ── Phase 3: Language filter ─────────────────────────────────────────
     _t = time.time()
-    print("\n[phase 3] Language detection...")
+    log.info("Phase 3: Language detection...")
     _lang_model_path = str(lang_model_path)
     ds = ds.map(
         lambda batch: detect_language_batch(batch["text"], _lang_model_path),
@@ -1056,7 +1050,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
     )
     ds = ds.remove_columns(["lang", "lang_conf"])
     after_lang = len(ds)
-    print(
+    log.info(
         f"  kept {after_lang:,} / {before_lang:,}"
         f" (removed {before_lang - after_lang:,})"
         f"  [{time.time() - _t:.0f}s]"
@@ -1071,12 +1065,12 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
     subset_seed = seed
 
     if not topic_classes or skip_topic_filter:
-        print("\n[phase 3.5] Topic filter... SKIPPED")
+        log.info("Phase 3.5: Topic filter... SKIPPED")
         after_topic = len(ds)
     else:
         _t = time.time()
-        print(f"\n[phase 3.5] Topic classification (keep: {topic_classes})...")
-        print(f"  Model: {TOPIC_MODEL_NAME}")
+        log.info(f"Phase 3.5: Topic classification (keep: {topic_classes})...")
+        log.info(f"  Model: {TOPIC_MODEL_NAME}")
 
         pipe = _get_topic_pipeline()
         from tqdm import tqdm as _tqdm
@@ -1118,8 +1112,8 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
                         total_after_filter * topic_distribution[cls] / weight_sum
                     )
                     if len(available) < target_count:
-                        print(
-                            f"  [warn] '{cls}': only {len(available):,} docs "
+                        log.warning(
+                            f"'{cls}': only {len(available):,} docs "
                             f"available, target was {target_count:,} — using all."
                         )
                         final_indices.extend(available)
@@ -1135,10 +1129,10 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
         for cls in topic_classes:
             n_cls = sum(1 for lbl in kept_labels if lbl == cls)
             pct = 100.0 * n_cls / max(len(ds), 1)
-            print(f"  {cls}: {n_cls:,} docs ({pct:.1f}%)")
+            log.info(f"  {cls}: {n_cls:,} docs ({pct:.1f}%)")
 
         after_topic = len(ds)
-        print(
+        log.info(
             f"  kept {after_topic:,} / {before_topic:,}"
             f" (removed {before_topic - after_topic:,})"
             f"  [{time.time() - _t:.0f}s]"
@@ -1151,10 +1145,10 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
     skip_quality_filter = getattr(args, "skip_quality_filter", False)
 
     if filter_mode == "none" or skip_code_filter:
-        print("\n[phase 4] Code/artifact removal... SKIPPED")
+        log.info("Phase 4: Code/artifact removal... SKIPPED")
         after_code = len(ds)
     elif filter_mode == "heuristic":
-        print("\n[phase 4] Code/artifact removal (heuristic)...")
+        log.info("Phase 4: Code/artifact removal (heuristic)...")
         ds = ds.map(
             lambda batch: heuristic_code_filter_batch(batch["text"]),
             batched=True,
@@ -1168,7 +1162,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
         )
         ds = ds.remove_columns(["code_filter_status"])
         after_code = len(ds)
-        print(
+        log.info(
             f"  kept {after_code:,} / {before_code:,}"
             f" (removed {before_code - after_code:,})"
         )
@@ -1179,7 +1173,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
                 f"Code classifier model not found at {code_model_path}. "
                 "Train it with: uv run python src/scripts/train_filter_models.py code-classifier"
             )
-        print("\n[phase 4] Code/artifact removal (classifier)...")
+        log.info("Phase 4: Code/artifact removal (classifier)...")
         _code_model_path = str(code_model_path)
         ds = ds.map(
             lambda batch: classifier_code_filter_batch(batch["text"], _code_model_path),
@@ -1194,17 +1188,17 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
         )
         ds = ds.remove_columns([c for c in ["code_filter_status", "code_score"] if c in ds.column_names])
         after_code = len(ds)
-        print(
+        log.info(
             f"  kept {after_code:,} / {before_code:,}"
             f" (removed {before_code - after_code:,})"
         )
 
     # ── Phase 5: Quality / coherence filter ───────────────────────────────
     if filter_mode == "none" or skip_quality_filter:
-        print("\n[phase 5] Quality/coherence filter... SKIPPED")
+        log.info("Phase 5: Quality/coherence filter... SKIPPED")
         after_quality = len(ds)
     elif filter_mode == "heuristic":
-        print("\n[phase 5] Quality/coherence filter (heuristic)...")
+        log.info("Phase 5: Quality/coherence filter (heuristic)...")
         ds = ds.map(
             lambda batch: heuristic_quality_filter_batch(batch["text"]),
             batched=True,
@@ -1218,7 +1212,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
         )
         ds = ds.remove_columns(["quality_filter_status"])
         after_quality = len(ds)
-        print(
+        log.info(
             f"  kept {after_quality:,} / {before_quality:,}"
             f" (removed {before_quality - after_quality:,})"
         )
@@ -1242,7 +1236,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
                 "kenlm is required for --filter-mode classifier. "
                 "Install with: pip install 'parrotllm[classifier]'"
             )
-        print("\n[phase 5] Quality/coherence filter (classifier)...")
+        log.info("Phase 5: Quality/coherence filter (classifier)...")
         _kenlm_model = _kenlm.Model(str(kenlm_path))
         _edu_path = str(edu_path)
         ds = ds.map(
@@ -1260,7 +1254,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
         )
         ds = ds.remove_columns([c for c in ["quality_filter_status", "perplexity", "edu_score"] if c in ds.column_names])
         after_quality = len(ds)
-        print(
+        log.info(
             f"  kept {after_quality:,} / {before_quality:,}"
             f" (removed {before_quality - after_quality:,})"
         )
@@ -1268,10 +1262,10 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
     # ── Phase 6: Fuzzy deduplication ──────────────────────────────────────
     skip_dedup = getattr(args, "skip_dedup", False)
     if skip_dedup:
-        print("\n[phase 6] Fuzzy deduplication... SKIPPED")
+        log.info("Phase 6: Fuzzy deduplication... SKIPPED")
         after_dedup = len(ds)
     else:
-        print("\n[phase 6] Fuzzy deduplication...")
+        log.info("Phase 6: Fuzzy deduplication...")
         ds = ds.map(
             _minhash_signature_batch,
             input_columns=["text"],
@@ -1285,15 +1279,15 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
         ds = ds.select([i for i in range(len(ds)) if i not in dup_indices])
         ds = ds.remove_columns(["minhash_sig"])
         after_dedup = len(ds)
-        print(f"  kept {after_dedup:,} / {before_dedup:,} (removed {before_dedup - after_dedup:,} near-duplicates)")
+        log.info(f"  kept {after_dedup:,} / {before_dedup:,} (removed {before_dedup - after_dedup:,} near-duplicates)")
 
     # ── Phase 6.1: Ellipsis filter ──────────────────────────────────────────
     skip_ellipsis_filter = getattr(args, "skip_ellipsis_filter", False)
     if skip_ellipsis_filter:
-        print("\n[phase 6.1] Ellipsis filter... SKIPPED")
+        log.info("Phase 6.1: Ellipsis filter... SKIPPED")
         after_ellipsis = len(ds)
     else:
-        print("\n[phase 6.1] Ellipsis filter...")
+        log.info("Phase 6.1: Ellipsis filter...")
         ds = ds.map(
             lambda batch: ellipsis_filter_batch(batch["text"]),
             batched=True,
@@ -1304,14 +1298,14 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
         ds = ds.filter(lambda row: row["ellipsis_filter_status"] == "kept", num_proc=num_workers)
         ds = ds.remove_columns(["ellipsis_filter_status"])
         after_ellipsis = len(ds)
-        print(
+        log.info(
             f"  kept {after_ellipsis:,} / {before_ellipsis:,}"
             f" (removed {before_ellipsis - after_ellipsis:,})"
         )
 
 # ── Phase 7: Tokenization ──────────────────────────────────────────
     _t = time.time()
-    print("\n[phase 7] Tokenization...")
+    log.info("Phase 7: Tokenization...")
     ds = ds.map(
         lambda batch: tokenize_batch(batch["text"], tokenizer),
         batched=True,
@@ -1321,7 +1315,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
     before_tok = len(ds)
     ds = ds.filter(lambda row: row["n_tokens"] >= 64, num_proc=1)
     after_tok = len(ds)
-    print(
+    log.info(
         f"  kept {after_tok:,} / {before_tok:,}"
         f" (removed {before_tok - after_tok:,} short docs)"
         f"  [{time.time() - _t:.0f}s]"
@@ -1331,19 +1325,19 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
     _skip_code = filter_mode == "none" or skip_code_filter
     _skip_quality = filter_mode == "none" or skip_quality_filter
     _skip_topic = not topic_classes or skip_topic_filter
-    print(f"\n[preprocess] Filter summary:")
-    print(f"  input:            {total_docs:,}")
-    print(f"  after decontam:   {after_decontam:,}{' (skipped)' if skip_decontam else ''}")
-    print(f"  after sanitize:   {after_sanitize:,}")
-    print(f"  after lang:       {after_lang:,}")
-    print(f"  after topic:      {after_topic:,}{' (skipped)' if _skip_topic else ''}")
-    print(f"  after code filter:{after_code:,}{' (skipped)' if _skip_code else ''}")
-    print(f"  after quality:    {after_quality:,}{' (skipped)' if _skip_quality else ''}")
-    print(f"  after dedup:      {after_dedup:,}{' (skipped)' if skip_dedup else ''}")
-    print(f"  after ellipsis:   {after_ellipsis:,}{' (skipped)' if skip_ellipsis_filter else ''}")
-    print(f"  after tokenize:   {after_tok:,}")
+    log.info(f"Filter summary:")
+    log.info(f"  input:            {total_docs:,}")
+    log.info(f"  after decontam:   {after_decontam:,}{' (skipped)' if skip_decontam else ''}")
+    log.info(f"  after sanitize:   {after_sanitize:,}")
+    log.info(f"  after lang:       {after_lang:,}")
+    log.info(f"  after topic:      {after_topic:,}{' (skipped)' if _skip_topic else ''}")
+    log.info(f"  after code filter:{after_code:,}{' (skipped)' if _skip_code else ''}")
+    log.info(f"  after quality:    {after_quality:,}{' (skipped)' if _skip_quality else ''}")
+    log.info(f"  after dedup:      {after_dedup:,}{' (skipped)' if skip_dedup else ''}")
+    log.info(f"  after ellipsis:   {after_ellipsis:,}{' (skipped)' if skip_ellipsis_filter else ''}")
+    log.info(f"  after tokenize:   {after_tok:,}")
 
-    print("\n[phase 8] Writing binary output...")
+    log.info("Phase 8: Writing binary output...")
     # Flatten all per-document token ID lists into a single contiguous array.
     # use of itertools.chain.from_iterable as it is ~5× faster than a Python-level extend loop
     # over millions of rows because the chaining happens in C.  Providing the
@@ -1353,7 +1347,7 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
         dtype=np.uint16,
         count=int(sum(ds["n_tokens"])),
     )
-    print(f"  Total tokens kept: {len(token_array):,}")
+    log.info(f"  Total tokens kept: {len(token_array):,}")
 
     # Reserve the first 1 % of tokens for validation; the rest become training data.
     # Taking from the front keeps val tokens contiguous on disk; the 1 % figure
@@ -1379,8 +1373,8 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
 
     train_tokens = _pad_to_chunk(train_tokens)
     val_tokens   = _pad_to_chunk(val_tokens)
-    print(f"  train: {len(train_tokens):,} tokens → {len(train_tokens) // chunk_size:,} complete chunks (chunk_size={chunk_size})")
-    print(f"  val:   {len(val_tokens):,} tokens → {len(val_tokens) // chunk_size:,} complete chunks")
+    log.info(f"  train: {len(train_tokens):,} tokens → {len(train_tokens) // chunk_size:,} complete chunks (chunk_size={chunk_size})")
+    log.info(f"  val:   {len(val_tokens):,} tokens → {len(val_tokens) // chunk_size:,} complete chunks")
 
     # Save
     train_path = out_dir / "train.bin"
@@ -1388,11 +1382,11 @@ def run_preprocess(args: PreprocessConfig, seed: int) -> None:
     train_tokens.tofile(str(train_path))
     val_tokens.tofile(str(val_path))
 
-    print(f"\n[done] train: {train_tokens.nbytes / 1e6:.1f} MB -> {train_path}")
-    print(f"[done] val:   {val_tokens.nbytes / 1e6:.1f} MB -> {val_path}")
+    log.info(f"train: {train_tokens.nbytes / 1e6:.1f} MB -> {train_path}")
+    log.info(f"val:   {val_tokens.nbytes / 1e6:.1f} MB -> {val_path}")
 
     # Clean up temporary HF dataset cache written during this run
     _hf_cache = Path(os.environ.get("HF_DATASETS_CACHE", "/tmp/parrotllm_hf_cache"))
     if _hf_cache.exists() and str(_hf_cache).startswith("/tmp"):
         shutil.rmtree(_hf_cache, ignore_errors=True)
-        print(f"[cleanup] Removed temporary HF cache at {_hf_cache}")
+        log.info(f"Removed temporary HF cache at {_hf_cache}")

--- a/src/eval/inference.py
+++ b/src/eval/inference.py
@@ -1,8 +1,11 @@
 """Autoregressive generation and leaderboard inference."""
 
+import logging
 import sys
 
 import torch
+
+log = logging.getLogger("parrotllm.inference")
 
 from configs import ProjectConfig
 from src.model import HuggingFaceGPT2, ParrotLLM
@@ -82,10 +85,10 @@ def run_inference(
 
     if use_mock:
         if hf_token:
-            print("[inference] Using Hugging Face token from .env")
+            log.info("Using Hugging Face token from .env")
         model = HuggingFaceGPT2().to(device)
         mc = {"context_length": getattr(model, "context_length", 1024)}
-        print("[inference] mock_testing enabled: using openai-community/gpt2")
+        log.info("mock_testing enabled: using openai-community/gpt2")
     else:
         assert checkpoint, "--checkpoint required for inference"
         model, ckpt_config = load_model_from_checkpoint(checkpoint, device)
@@ -117,5 +120,5 @@ def run_inference(
         generated = tokenizer.decode(output[0, len(input_ids):].tolist())
         sys.stdout.write(generated)
     else:
-        print(f"[inference] prompt: {input_text}")
-        print(f"[inference] output: {text}")
+        log.info(f"prompt: {input_text}")
+        log.info(f"output: {text}")

--- a/src/eval/perplexity.py
+++ b/src/eval/perplexity.py
@@ -1,7 +1,10 @@
 """Evaluate perplexity on Wikitext-103 and OWT validation split."""
 
+import logging
 import math
 from typing import Dict
+
+log = logging.getLogger("parrotllm.eval")
 
 import numpy as np
 import torch
@@ -119,8 +122,8 @@ def run_eval(
     model = ParrotLLM(ckpt_config).to(device)
     model.load_state_dict(ckpt["model"])
     model.eval()
-    print(f"[eval] loaded checkpoint: {checkpoint}")
-    print(f"[eval] parameters: {model.count_parameters():,}")
+    log.info(f"loaded checkpoint: {checkpoint}")
+    log.info(f"parameters: {model.count_parameters():,}")
 
     # Wikitext-103
     try:
@@ -135,9 +138,9 @@ def run_eval(
                 eval_cfg.max_sequences,
                 hf_token,
             )
-            print(f"[eval] Wikitext-103 perplexity: {wt_ppl:.2f}")
+            log.info(f"Wikitext-103 perplexity: {wt_ppl:.2f}")
     except Exception as e:
-        print(f"[eval] Wikitext-103 skipped: {e}")
+        log.warning(f"Wikitext-103 skipped: {e}")
 
     # OWT val
     try:
@@ -150,6 +153,6 @@ def run_eval(
             eval_cfg.batch_size,
             eval_cfg.max_sequences,
         )
-        print(f"[eval] OWT val perplexity: {owt_ppl:.2f}")
+        log.info(f"OWT val perplexity: {owt_ppl:.2f}")
     except Exception as e:
-        print(f"[eval] OWT val skipped: {e}")
+        log.warning(f"OWT val skipped: {e}")

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -11,6 +11,34 @@ import os
 from datetime import datetime, timezone
 
 
+def init_logging(
+    *,
+    console_level: str = "INFO",
+    component_levels: dict[str, str] | None = None,
+) -> logging.Logger:
+    """Set up console-only logging for non-training stages."""
+    logger = logging.getLogger("parrotllm")
+    logger.setLevel(logging.DEBUG)
+    logger.handlers.clear()
+
+    fmt = logging.Formatter(
+        "%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    ch = logging.StreamHandler()
+    ch.setLevel(getattr(logging, console_level.upper(), logging.INFO))
+    ch.setFormatter(fmt)
+    logger.addHandler(ch)
+
+    if component_levels:
+        for component, level in component_levels.items():
+            child = logging.getLogger(f"parrotllm.{component}")
+            child.setLevel(getattr(logging, level.upper(), logging.DEBUG))
+
+    return logger
+
+
 def setup_logger(
     run_dir: str,
     *,
@@ -38,7 +66,7 @@ def setup_logger(
     logger.handlers.clear()
 
     fmt = logging.Formatter(
-        "%(asctime)s - %(levelname)s - %(message)s",
+        "%(asctime)s - %(levelname)s - %(name)s - %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -154,21 +154,22 @@ def fmt_model_summary(
         f"  Dropout: {mc.get('dropout', 0.0)}",
         f"  Bias: {mc.get('bias', False)}",
         "",
-        "Parameters:",
-        f"  Total (non-embedding): {fmt_param_count(n_non_emb)}",
-        f"  Total (all): {fmt_param_count(n_params)}",
+        "Parameters (unique, weight-tied layers counted once):",
+        f"  Total: {fmt_param_count(n_params)}",
+        f"  Trainable: {fmt_param_count(n_trainable)}",
+        f"  Non-trainable: {fmt_param_count(n_non_trainable)}",
+        f"  Non-embedding: {fmt_param_count(n_non_emb)}",
         f"  Position embeddings: {fmt_param_count(pos_emb_params)}",
+        f"  Size (MB): {params_size_mb:.2f}",
     ]
     if torchinfo:
-        parts.append("")
-        parts.append(torchinfo)
-    parts += [
-        "",
-        f"Trainable params: {n_trainable:,}",
-        f"Non-trainable params: {n_non_trainable:,}",
-        f"Params size (MB): {params_size_mb:.2f}",
-        "=" * 60,
-    ]
+        parts += [
+            "",
+            "Layer-wise breakdown (torchinfo):",
+            "  Note: torchinfo double-counts weight-tied layers (tok_emb/lm_head).",
+            torchinfo,
+        ]
+    parts.append("=" * 60)
     return "\n".join(parts)
 
 

--- a/src/logging_utils.py
+++ b/src/logging_utils.py
@@ -118,6 +118,130 @@ class JSONLLogger:
         self._file.close()
 
 
+def fmt_param_count(n: int) -> str:
+    """Format a parameter count with human-readable suffix."""
+    if n >= 1_000_000:
+        return f"{n:,} ({n / 1e6:.2f}M)"
+    if n >= 1_000:
+        return f"{n:,} ({n / 1e3:.1f}K)"
+    return f"{n:,}"
+
+
+def fmt_model_summary(
+    mc: dict,
+    *,
+    n_params: int,
+    n_non_emb: int,
+    pos_emb_params: int,
+    n_trainable: int,
+    n_non_trainable: int,
+    params_size_mb: float,
+    torchinfo: str | None = None,
+) -> str:
+    """Build a multi-line model architecture summary string."""
+    parts = [
+        "\n" + "=" * 60,
+        "MODEL ARCHITECTURE SUMMARY",
+        "=" * 60,
+        "",
+        "Configuration:",
+        f"  Vocab size: {mc['vocab_size']}",
+        f"  Block size (context): {mc['context_length']}",
+        f"  Layers: {mc['n_layers']}",
+        f"  Heads: {mc['n_heads']}",
+        f"  Embedding dim: {mc['d_model']}",
+        f"  FFN hidden dim: {mc['d_ff']}",
+        f"  Dropout: {mc.get('dropout', 0.0)}",
+        f"  Bias: {mc.get('bias', False)}",
+        "",
+        "Parameters:",
+        f"  Total (non-embedding): {fmt_param_count(n_non_emb)}",
+        f"  Total (all): {fmt_param_count(n_params)}",
+        f"  Position embeddings: {fmt_param_count(pos_emb_params)}",
+    ]
+    if torchinfo:
+        parts.append("")
+        parts.append(torchinfo)
+    parts += [
+        "",
+        f"Trainable params: {n_trainable:,}",
+        f"Non-trainable params: {n_non_trainable:,}",
+        f"Params size (MB): {params_size_mb:.2f}",
+        "=" * 60,
+    ]
+    return "\n".join(parts)
+
+
+def fmt_training_start(steps_per_epoch: int, max_steps: int) -> str:
+    """Build the training-start banner string."""
+    return (
+        "\n" + "=" * 60
+        + "\nStarting training..."
+        + f"\n  Steps per epoch (approx): {steps_per_epoch}"
+        + f"\n  Max steps: {max_steps}"
+        + "\n" + "=" * 60
+    )
+
+
+def fmt_training_complete(
+    epochs: int, total_steps: int, total_hours: float,
+    best_val_loss: float, run_dir: str,
+) -> str:
+    """Build the training-complete summary string."""
+    return (
+        "\n" + "=" * 60
+        + "\nTRAINING COMPLETE"
+        + "\n" + "=" * 60
+        + f"\n  Epochs: {epochs}"
+        + f"\n  Total steps: {total_steps}"
+        + f"\n  Total time: {total_hours:.2f} hours"
+        + f"\n  Best validation loss: {best_val_loss:.4f}"
+        + f"\n  Run directory: {run_dir}"
+        + "\n" + "=" * 60
+    )
+
+
+def render_ascii_loss_curve(
+    loss_history: list[tuple[int, float]], width: int = 50, height: int = 8,
+) -> str:
+    """Render an ASCII loss curve and return it as a single string."""
+    if not loss_history:
+        return ""
+
+    steps = [s for s, _ in loss_history]
+    losses = [l for _, l in loss_history]
+    min_loss, max_loss = min(losses), max(losses)
+    min_step, max_step = min(steps), max(steps)
+
+    if max_loss == min_loss:
+        max_loss = min_loss + 1
+
+    grid = [[" " for _ in range(width)] for _ in range(height)]
+    step_range = max(max_step - min_step, 1)
+    loss_range = max_loss - min_loss
+
+    for s, l in loss_history:
+        x = int((s - min_step) / step_range * (width - 1))
+        y = int((l - min_loss) / loss_range * (height - 1))
+        y = height - 1 - y
+        x = max(0, min(width - 1, x))
+        y = max(0, min(height - 1, y))
+        grid[y][x] = "*"
+
+    lines = ["Loss Curve:", "  Loss", "  ^"]
+    for i, row in enumerate(grid):
+        if i == 0:
+            label = f"{max_loss:>8.2f}"
+        elif i == height - 1:
+            label = f"{min_loss:>8.2f}"
+        else:
+            label = "        "
+        lines.append(f"{label} |{''.join(row)}")
+    lines.append(f"         +{'-' * width}> step")
+    lines.append(f"         {min_step:<{width // 2}}{max_step:>{width - width // 2}}")
+    return "\n".join(lines)
+
+
 def make_run_dir(runs_dir: str = "runs", tag: str | None = None) -> str:
     """Create a timestamped run directory, e.g. runs/run_20260306_143641[_tag]/."""
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -10,8 +10,11 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from configs import LoggingConfig, ProjectConfig
-from src.logging_utils import JSONLLogger, make_run_dir, setup_logger
+from configs import ProjectConfig
+from src.logging_utils import (
+    JSONLLogger, fmt_model_summary, fmt_training_complete,
+    fmt_training_start, make_run_dir, render_ascii_loss_curve, setup_logger,
+)
 from src.model import ParrotLLM
 
 
@@ -95,7 +98,7 @@ def save_checkpoint(model: nn.Module, optimizer: torch.optim.Optimizer,
     if scaler is not None:
         state["scaler"] = scaler.state_dict()
     torch.save(state, path)
-    logging.getLogger("parrotllm").debug(f"Checkpoint saved: {path}")
+    logging.getLogger("parrotllm.training").debug(f"Checkpoint saved: {path}")
 
 
 def load_checkpoint(path: str, model: nn.Module,
@@ -140,125 +143,47 @@ def estimate_loss(model: nn.Module, dataset: PretrainingDataset,
 def _log_model_architecture(log: logging.Logger, jlog: JSONLLogger,
                             model: nn.Module, mc: dict,
                             device: torch.device, batch_size: int) -> None:
-    """Log model architecture summary matching the slide 12 example."""
+    """Log model architecture summary."""
     n_params = model.count_parameters()
     n_all = sum(p.numel() for p in model.parameters())
     n_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
     n_non_trainable = n_all - n_trainable
-
-    # Embedding param count
-    tok_emb_params = model.tok_emb.weight.numel()
     pos_emb_params = model.pos_emb.weight.numel()
-    n_non_emb = n_params - pos_emb_params  # tok_emb is tied with lm_head
-
-    def _fmt(n: int) -> str:
-        if n >= 1_000_000:
-            return f"{n:,} ({n / 1e6:.2f}M)"
-        if n >= 1_000:
-            return f"{n:,} ({n / 1e3:.1f}K)"
-        return f"{n:,}"
-
-    log.info("")
-    log.info("=" * 60)
-    log.info("MODEL ARCHITECTURE SUMMARY")
-    log.info("=" * 60)
-    log.info("")
-    log.info("Configuration:")
-    log.info(f"  Vocab size: {mc['vocab_size']}")
-    log.info(f"  Block size (context): {mc['context_length']}")
-    log.info(f"  Layers: {mc['n_layers']}")
-    log.info(f"  Heads: {mc['n_heads']}")
-    log.info(f"  Embedding dim: {mc['d_model']}")
-    log.info(f"  FFN hidden dim: {mc['d_ff']}")
-    log.info(f"  Dropout: {mc.get('dropout', 0.0)}")
-    log.info(f"  Bias: {mc.get('bias', False)}")
-    log.info("")
-    log.info("Parameters:")
-    log.info(f"  Total (non-embedding): {_fmt(n_non_emb)}")
-    log.info(f"  Total (all): {_fmt(n_params)}")
-    log.info(f"  Position embeddings: {_fmt(pos_emb_params)}")
-    log.info("")
+    n_non_emb = n_params - pos_emb_params
+    params_size_mb = n_all * 4 / 1e6
 
     # torchinfo summary (if available)
+    torchinfo_str = None
     try:
         from torchinfo import summary
-        B = batch_size
-        T = mc["context_length"]
-        dummy_input = torch.randint(0, mc["vocab_size"], (B, T), device=device)
+        dummy_input = torch.randint(
+            0, mc["vocab_size"], (batch_size, mc["context_length"]), device=device,
+        )
         stats = summary(
             model, input_data=(dummy_input,),
             col_names=("input_size", "output_size", "num_params", "trainable"),
             depth=3, verbose=0,
         )
-        for line in str(stats).splitlines():
-            log.info(line)
+        torchinfo_str = str(stats)
     except ImportError:
         log.debug("torchinfo not installed, skipping layer-wise summary")
 
-    log.info("")
-    log.info(f"Trainable params: {n_trainable:,}")
-    log.info(f"Non-trainable params: {n_non_trainable:,}")
-    log.info(f"Params size (MB): {n_all * 4 / 1e6:.2f}")
-    log.info("")
-    log.info("=" * 60)
+    log.info(fmt_model_summary(
+        mc,
+        n_params=n_params, n_non_emb=n_non_emb, pos_emb_params=pos_emb_params,
+        n_trainable=n_trainable, n_non_trainable=n_non_trainable,
+        params_size_mb=params_size_mb, torchinfo=torchinfo_str,
+    ))
 
-    # JSONL: structured architecture record
     jlog.log("pretraining", "model_architecture",
              vocab_size=mc["vocab_size"],
              context_length=mc["context_length"],
-             n_layers=mc["n_layers"],
-             n_heads=mc["n_heads"],
-             d_model=mc["d_model"],
-             d_ff=mc["d_ff"],
-             dropout=mc.get("dropout", 0.0),
-             bias=mc.get("bias", False),
-             total_params=n_params,
-             total_params_non_embedding=n_non_emb,
-             trainable_params=n_trainable,
-             non_trainable_params=n_non_trainable,
-             params_size_mb=round(n_all * 4 / 1e6, 2))
-
-
-def _render_ascii_loss_curve(
-    loss_history: list[tuple[int, float]], width: int = 50, height: int = 8,
-) -> list[str]:
-    """Render a simple ASCII loss curve for the training log."""
-    if not loss_history:
-        return []
-
-    steps = [s for s, _ in loss_history]
-    losses = [l for _, l in loss_history]
-    min_loss, max_loss = min(losses), max(losses)
-    min_step, max_step = min(steps), max(steps)
-
-    if max_loss == min_loss:
-        max_loss = min_loss + 1
-
-    # Build character grid
-    grid = [[" " for _ in range(width)] for _ in range(height)]
-    step_range = max(max_step - min_step, 1)
-    loss_range = max_loss - min_loss
-
-    for s, l in loss_history:
-        x = int((s - min_step) / step_range * (width - 1))
-        y = int((l - min_loss) / loss_range * (height - 1))
-        y = height - 1 - y  # flip so high loss is at top
-        x = max(0, min(width - 1, x))
-        y = max(0, min(height - 1, y))
-        grid[y][x] = "*"
-
-    lines = ["Loss Curve:", "  Loss", "  ^"]
-    for i, row in enumerate(grid):
-        if i == 0:
-            label = f"{max_loss:>8.2f}"
-        elif i == height - 1:
-            label = f"{min_loss:>8.2f}"
-        else:
-            label = "        "
-        lines.append(f"{label} |{''.join(row)}")
-    lines.append(f"         +{'-' * width}> step")
-    lines.append(f"         {min_step:<{width // 2}}{max_step:>{width - width // 2}}")
-    return lines
+             n_layers=mc["n_layers"], n_heads=mc["n_heads"],
+             d_model=mc["d_model"], d_ff=mc["d_ff"],
+             dropout=mc.get("dropout", 0.0), bias=mc.get("bias", False),
+             total_params=n_params, total_params_non_embedding=n_non_emb,
+             trainable_params=n_trainable, non_trainable_params=n_non_trainable,
+             params_size_mb=round(params_size_mb, 2))
 
 
 def run_train(
@@ -279,12 +204,13 @@ def run_train(
 
     # ── run directory & loggers ───────────────────────────────────────────────
     run_dir = make_run_dir(tc_model.runs_dir)
-    log = setup_logger(
+    setup_logger(
         run_dir,
         console_level=lc_model.console_level,
         file_level=lc_model.file_level,
         component_levels=lc_model.components if lc_model.components else None,
     )
+    log = logging.getLogger("parrotllm.training")
     jlog = JSONLLogger(run_dir)
 
     # Save full config to run directory for reproducibility
@@ -347,13 +273,7 @@ def run_train(
     prev_epoch = 0
     loss_history: list[tuple[int, float]] = []
     
-    log.info("")
-    log.info("=" * 60)
-    log.info("Starting training...")
-    log.info(f"  Steps per epoch (approx): {steps_per_epoch}")
-    log.info(f"  Max steps: {tc['max_steps']}")
-    log.info("=" * 60)
-    log.info("")
+    log.info(fmt_training_start(steps_per_epoch, tc["max_steps"]))
 
     for step in range(start_step, tc["max_steps"]):
         epoch = step // steps_per_epoch if steps_per_epoch > 0 else 0
@@ -462,23 +382,16 @@ def run_train(
              step=tc["max_steps"], epoch=epoch, path=final_ckpt)
 
     # ── ASCII loss curve ───────────────────────────────────────────────────────
-    log.info("")
-    for line in _render_ascii_loss_curve(loss_history):
-        log.info(line)
+    curve = render_ascii_loss_curve(loss_history)
+    if curve:
+        log.info("\n" + curve)
 
-    # ── training complete summary (slide 12 style) ────────────────────────────
+    # ── training complete summary ─────────────────────────────────────────────
     total_seconds = time.time() - train_start
     total_hours = total_seconds / 3600
-    log.info("")
-    log.info("=" * 60)
-    log.info("TRAINING COMPLETE")
-    log.info("=" * 60)
-    log.info(f"  Epochs: {epoch + 1}")
-    log.info(f"  Total steps: {tc['max_steps']}")
-    log.info(f"  Total time: {total_hours:.2f} hours")
-    log.info(f"  Best validation loss: {best_val_loss:.4f}")
-    log.info(f"  Run directory: {run_dir}")
-    log.info("=" * 60)
+    log.info(fmt_training_complete(
+        epoch + 1, tc["max_steps"], total_hours, best_val_loss, run_dir,
+    ))
 
     jlog.log("pretraining", "training_complete",
              epochs=epoch + 1,

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -144,13 +144,20 @@ def _log_model_architecture(log: logging.Logger, jlog: JSONLLogger,
                             model: nn.Module, mc: dict,
                             device: torch.device, batch_size: int) -> None:
     """Log model architecture summary."""
-    n_params = model.count_parameters()
-    n_all = sum(p.numel() for p in model.parameters())
-    n_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
-    n_non_trainable = n_all - n_trainable
+    # Deduplicate by data_ptr to handle weight tying (tok_emb == lm_head)
+    seen = set()
+    n_total = 0
+    n_trainable = 0
+    for p in model.parameters():
+        if p.data_ptr() not in seen:
+            seen.add(p.data_ptr())
+            n_total += p.numel()
+            if p.requires_grad:
+                n_trainable += p.numel()
+    n_non_trainable = n_total - n_trainable
     pos_emb_params = model.pos_emb.weight.numel()
-    n_non_emb = n_params - pos_emb_params
-    params_size_mb = n_all * 4 / 1e6
+    n_non_emb = n_total - pos_emb_params
+    params_size_mb = n_total * 4 / 1e6
 
     # torchinfo summary (if available)
     torchinfo_str = None
@@ -170,7 +177,7 @@ def _log_model_architecture(log: logging.Logger, jlog: JSONLLogger,
 
     log.info(fmt_model_summary(
         mc,
-        n_params=n_params, n_non_emb=n_non_emb, pos_emb_params=pos_emb_params,
+        n_params=n_total, n_non_emb=n_non_emb, pos_emb_params=pos_emb_params,
         n_trainable=n_trainable, n_non_trainable=n_non_trainable,
         params_size_mb=params_size_mb, torchinfo=torchinfo_str,
     ))
@@ -181,7 +188,7 @@ def _log_model_architecture(log: logging.Logger, jlog: JSONLLogger,
              n_layers=mc["n_layers"], n_heads=mc["n_heads"],
              d_model=mc["d_model"], d_ff=mc["d_ff"],
              dropout=mc.get("dropout", 0.0), bias=mc.get("bias", False),
-             total_params=n_params, total_params_non_embedding=n_non_emb,
+             total_params=n_total, total_params_non_embedding=n_non_emb,
              trainable_params=n_trainable, non_trainable_params=n_non_trainable,
              params_size_mb=round(params_size_mb, 2))
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -8,6 +8,19 @@ import tempfile
 from src.logging_utils import JSONLLogger, make_run_dir, setup_logger
 
 
+def test_init_logging_console_only():
+    """init_logging sets up console handler on root parrotllm logger."""
+    from src.logging_utils import init_logging
+
+    log = init_logging(console_level="WARNING")
+    assert log.name == "parrotllm"
+    console_handlers = [h for h in log.handlers if isinstance(h, logging.StreamHandler)
+                        and not isinstance(h, logging.FileHandler)]
+    assert len(console_handlers) == 1
+    assert console_handlers[0].level == logging.WARNING
+    log.handlers.clear()
+
+
 def test_setup_logger_creates_log_file():
     with tempfile.TemporaryDirectory() as tmp:
         log = setup_logger(tmp, console_level="WARNING", file_level="DEBUG")


### PR DESCRIPTION
## Summary
- Add `init_logging()` to `src/logging_utils.py` for console-only stages (preprocess, eval, inference, chat)
- Replace all `print()` calls across the pipeline with proper `logging.getLogger("parrotllm.<stage>")` calls
- Move log formatting helpers (`fmt_model_summary`, `fmt_training_start`, `fmt_training_complete`, `render_ascii_loss_curve`) from `trainer.py` into `logging_utils.py`
- All stages now respect the YAML `logging:` config section (console_level, file_level, component overrides)

## Test plan
- [x] All 6 logging tests pass (`pytest tests/test_logging.py`)
- [ ] Run preprocessing with `--config configs/preprocess_dummy.yaml` and verify log output
- [ ] Run training with `--config configs/train_dummy.yaml` and verify formatted summaries
- [ ] Run inference with `--config configs/inference_dummy.yaml --mock-testing` and verify log output